### PR TITLE
Fix to make visual studio compile

### DIFF
--- a/include/belle.hh
+++ b/include/belle.hh
@@ -1348,7 +1348,7 @@ private:
             {
               return static_cast<int>(e);
             }
-            catch (std::exception const& e)
+            catch (std::exception const&)
             {
               return 500;
             }
@@ -1390,7 +1390,7 @@ private:
         {
           _ctx.res.result(e);
         }
-        catch (std::exception const& e)
+        catch (std::exception const&)
         {
           _ctx.res.result(500);
         }

--- a/include/belle.hh
+++ b/include/belle.hh
@@ -1196,10 +1196,15 @@ private:
 
   private:
 
+#ifndef _MSC_VER
     // generic lambda for sending different types of responses
-    static auto const constexpr send = [](auto self, auto&& res) -> void
+    static auto constexpr send = [](auto self, auto&& res) -> void
+#else
+    template <typename SELF_T, typename RES_T>
+    static constexpr void send(SELF_T self, RES_T&& res)
+#endif
     {
-      using item_type = typename std::remove_reference<decltype(res)>::type;
+      using item_type = std::remove_reference_t<decltype(res)>;
 
       auto ptr = std::make_shared<item_type>(std::move(res));
       self->_res = ptr;

--- a/include/belle.hh
+++ b/include/belle.hh
@@ -854,6 +854,7 @@ private:
   {
     // the public directory for serving static files
     std::string public_dir {};
+    std::string index_file{ "index.html" };
 
     // socket timeout
     std::chrono::seconds timeout {10};
@@ -1236,7 +1237,7 @@ private:
 
       if (path.back() == '/')
       {
-        path += "index.html";
+        path += _attr->index_file;
       }
 
       error_code ec;
@@ -1815,11 +1816,30 @@ public:
 
     return *this;
   }
-
+  
   // get the public directory for serving static files
   std::string public_dir()
   {
     return _attr->public_dir;
+  }
+
+  // overwrite the default index filename
+  Server& index_file(const std::string&& index_file_)
+  {
+     if (index_file_.empty())
+     {
+        _attr->index_file = "index.html";
+     }
+     else {
+        _attr->index_file = index_file_;
+     }
+     return *this;
+  }
+  
+  // get the default index filename
+  const std::string& index_file()
+  {
+     return _attr->index_file;
   }
 
   // set the number of threads


### PR DESCRIPTION
- Removed two unused exception variabes (every compiler should have complained about it...).
- A (ugly) workaround for visual studio.... this prevents the C2888 Compiler error for line 1201 and 1216.
- Removed some boilerplate code for the using.