### PR TITLE
Visual studio fix

### DIFF
--- a/include/belle.hh
+++ b/include/belle.hh
@@ -1348,7 +1348,7 @@ private:
             {
               return static_cast<int>(e);
             }
-            catch (std::exception const& e)
+            catch (std::exception const&)
             {
               return 500;
             }
@@ -1390,7 +1390,7 @@ private:
         {
           _ctx.res.result(e);
         }
-        catch (std::exception const& e)
+        catch (std::exception const&)
         {
           _ctx.res.result(500);
         }

--- a/include/belle.hh
+++ b/include/belle.hh
@@ -1196,10 +1196,15 @@ private:
 
   private:
 
+#ifndef _MSC_VER
     // generic lambda for sending different types of responses
-    static auto const constexpr send = [](auto self, auto&& res) -> void
+    static auto constexpr send = [](auto self, auto&& res) -> void
+#else
+    template <typename SELF_T, typename RES_T>
+    static constexpr void send(SELF_T self, RES_T&& res)
+#endif
     {
-      using item_type = typename std::remove_reference<decltype(res)>::type;
+      using item_type = std::remove_reference_t<decltype(res)>;
 
       auto ptr = std::make_shared<item_type>(std::move(res));
       self->_res = ptr;


### PR DESCRIPTION

    Removed two unused exception variabes (every compiler should have complained about it...).
    A (ugly) workaround for visual studio.... this prevents the C2888 Compiler error for line 1201 and 1216.
    Removed some boilerplate code for the using.
