### PR TITLE
Fix for the lacking generic lambda support in visual studio

### DIFF
--- a/include/belle.hh
+++ b/include/belle.hh
@@ -1197,8 +1197,8 @@ private:
   private:
 
 #ifdef _MSC_VER
-    template <typename SELF_T, typename RES_T>
-    static constexpr void send(SELF_T self, RES_T&& res)
+    template <typename Self, typename Res>
+    static constexpr void send(Self self, Res&& res)
 #else
     // generic lambda for sending different types of responses
     static auto const constexpr send = [](auto self, auto&& res) -> void

--- a/include/belle.hh
+++ b/include/belle.hh
@@ -1196,8 +1196,13 @@ private:
 
   private:
 
+#ifdef _MSC_VER
+    template <typename SELF_T, typename RES_T>
+    static constexpr void send(SELF_T self, RES_T&& res)
+#else
     // generic lambda for sending different types of responses
     static auto const constexpr send = [](auto self, auto&& res) -> void
+#endif
     {
       using item_type = typename std::remove_reference<decltype(res)>::type;
 


### PR DESCRIPTION
This this fix it compiles in visual studio 15.9.x.
Minded the discussion in  the other pull request.