### PR TITLE
Removed unused e in catch

### DIFF
--- a/include/belle.hh
+++ b/include/belle.hh
@@ -1348,7 +1348,7 @@ private:
             {
               return static_cast<int>(e);
             }
-            catch (std::exception const& e)
+            catch (std::exception const&)
             {
               return 500;
             }
@@ -1390,7 +1390,7 @@ private:
         {
           _ctx.res.result(e);
         }
-        catch (std::exception const& e)
+        catch (std::exception const&)
         {
           _ctx.res.result(500);
         }


### PR DESCRIPTION
As discussed before I think it's better to remove the e variable due to it's unused and add it again if's needed.